### PR TITLE
Redirect old react-jsonschema-form page to new one

### DIFF
--- a/react-jsonschema-form.html
+++ b/react-jsonschema-form.html
@@ -1,0 +1,7 @@
+<h2>This page has moved.</h2>
+
+If you are not automatically redirected, please go to <a id="link" href="https://rjsf-team.github.io/react-jsonschema-form/"></a>
+<script>
+window.location = "https://rjsf-team.github.io/react-jsonschema-form/" + window.location.hash;
+document.getElementById("link").href += window.location.hash;
+</script>


### PR DESCRIPTION
Fixes https://github.com/rjsf-team/react-jsonschema-form/issues/1448

Ever since react-jsonschema-form was moved from mozilla-services to rjsf-team, the old playground links were broken. This change makes it so that urls of the form

https://mozilla-services.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6ImEiLCJzY2hlbWEiOnsidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJhIn0sInVpU2NoZW1hIjp7InVpOmVtcHR5VmFsdWUiOiIifX0=

redirect to

https://rjsf-team.github.io/react-jsonschema-form/#eyJmb3JtRGF0YSI6ImEiLCJzY2hlbWEiOnsidHlwZSI6InN0cmluZyIsImRlZmF1bHQiOiJhIn0sInVpU2NoZW1hIjp7InVpOmVtcHR5VmFsdWUiOiIifX0=

@glasserc 