### PR TITLE
Fix rjsf redirection

### DIFF
--- a/react-jsonschema-form/index.html
+++ b/react-jsonschema-form/index.html
@@ -1,0 +1,7 @@
+<h2>This page has moved.</h2>
+
+If you are not automatically redirected, please go to <a id="link" href="https://rjsf-team.github.io/react-jsonschema-form/"></a>
+<script>
+window.location = "https://rjsf-team.github.io/react-jsonschema-form/" + window.location.hash;
+document.getElementById("link").href += window.location.hash;
+</script>


### PR DESCRIPTION
It seems that https://mozilla-services.github.io/react-jsonschema-form is redirecting but https://mozilla-services.github.io/react-jsonschema-form/ is not. Hopefully this PR will fix that.